### PR TITLE
Try provisioning a new free-tier GCP VM

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,6 +1,26 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.37.0"
+  constraints = "~> 4.37.0"
+  hashes = [
+    "h1:3pEF64vw56LuINvNDD1dLuXWIVXj8s45Lz4C/+YokZ4=",
+    "zh:01ae3e36f33651d2fa38499a13385f7a12df34cd6c5bbe59458f970f9e78a39a",
+    "zh:1c5bd5bb926216db863d1915f1c7c8ef5c4828931d7ac5446b1eec6f226bdd40",
+    "zh:1eac85f93f315a60b04206ada873b762453f126b5757cfc26a9073f2fafbd6a8",
+    "zh:422d7945c5556731d84ea4877a2d029f258e32efc59f4a473edfae0a6a1e925d",
+    "zh:66162f95d14c0db6c6fefb0f513192d840d401779603ee897518e9802748dde9",
+    "zh:679c23db26203be260b602fe88a7e622fca135074ab2746e567d048c07704113",
+    "zh:87404af4b1cad2922af395e229cdf683578c0ac99ccb2a141ada1cd623c850e5",
+    "zh:a8eec14b312b306aead96f880c62613a4000ae8b80e7aeef28054de5a380a7b8",
+    "zh:e367ce43096157cff544b0597383a266c964480c81f3f6d917cfdaccaaa6ee59",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f7bd4c60d7c9f36fadc177fe190ee62836aac38b1cbb6deebc8f60d3a72b5a4b",
+    "zh:fcf20dbf699f784cd04db84960beb5bb887ac5f049856251ec7f664dfacf83b9",
+  ]
+}
+
 provider "registry.terraform.io/zerotier/zerotier" {
   version     = "1.2.0"
   constraints = "~> 1.2.0"

--- a/networking.tf
+++ b/networking.tf
@@ -1,8 +1,8 @@
 provider "zerotier" {}
 
-resource "zerotier_network" "bootstrap" {
-  name        = "bootstrap.infra.sargassum.world"
-  description = "Control plane for bootstrapping sargassum.world"
+resource "zerotier_network" "foundations" {
+  name        = "foundations.infra.sargassum.world"
+  description = "Control plane for the foundations of sargassum.world"
 
   assign_ipv4 {
     zerotier = false

--- a/versions.tf
+++ b/versions.tf
@@ -12,5 +12,13 @@ terraform {
       source  = "zerotier/zerotier"
       version = "~> 1.2.0"
     }
+    /*hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~>1.35.2"
+    }*/
+    google = {
+      source  = "hashicorp/google"
+      version = "~>4.37.0"
+    }
   }
 }

--- a/vms.tf
+++ b/vms.tf
@@ -15,14 +15,14 @@ provider "google" {
   datacenter  = "dc14"
 }*/
 
-resource "google_kms_key_ring" "foundations-1" {
+resource "google_kms_key_ring" "disks-1" {
   name     = "foundations-1"
   location = "global"
 }
 
-resource "google_kms_crypto_key" "foundations-1-1" {
+resource "google_kms_crypto_key" "disk-1-1" {
   name            = "foundations-1"
-  key_ring        = google_kms_key_ring.foundations-1
+  key_ring        = google_kms_key_ring.disks-1.id
   rotation_period = "7777000s"
 
   lifecycle {
@@ -39,7 +39,7 @@ resource "google_compute_instance" "us-west1-a-1" {
     initialize_params {
       image = "ubuntu-os-cloud/ubuntu-minimal-2204-lts"
     }
-    disk_encryption_key_raw = google_kms_crypto_key.foundations-1-1
+    disk_encryption_key_raw = google_kms_crypto_key.disk-1-1.id
   }
 
   network_interface {

--- a/vms.tf
+++ b/vms.tf
@@ -23,7 +23,7 @@ resource "google_kms_key_ring" "disks-1" {
 resource "google_kms_crypto_key" "disk-1-1" {
   name            = "foundations-1"
   key_ring        = google_kms_key_ring.disks-1.id
-  rotation_period = "7777000s"
+  rotation_period = "7770000s"
 
   lifecycle {
     prevent_destroy = true

--- a/vms.tf
+++ b/vms.tf
@@ -1,0 +1,37 @@
+/*provider "hcloud" {
+}*/
+
+provider "google" {
+  project = "sargassum-world"
+  region  = "us-west1"
+  zone    = "us-west1-a"
+}
+
+/*resource "hcloud_server" "eu-central-fsn1-dc14-1" {
+  name        = "foundations-eu-central-fsn1-dc14-1"
+  server_type = "cpx11"
+  image       = "alpine-virt-3.16.0"
+  location    = "fsn1"
+  datacenter  = "dc14"
+  public_net {
+    ipv4_enabled = true
+    ipv6_enabled = true
+  }
+}*/
+
+resource "google_compute_instance" "us-west1-a-1" {
+  name         = "foundations-us-west1-a-1"
+  machine_type = "e2-micro"
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-minimal-2204-lts"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+    }
+  }
+}

--- a/vms.tf
+++ b/vms.tf
@@ -13,25 +13,45 @@ provider "google" {
   image       = "alpine-virt-3.16.0"
   location    = "fsn1"
   datacenter  = "dc14"
-  public_net {
-    ipv4_enabled = true
-    ipv6_enabled = true
-  }
 }*/
+
+resource "google_kms_key_ring" "foundations-1" {
+  name     = "foundations-1"
+  location = "global"
+}
+
+resource "google_kms_crypto_key" "foundations-1-1" {
+  name            = "foundations-1"
+  key_ring        = google_kms_key_ring.foundations-1
+  rotation_period = "7777000s"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
 
 resource "google_compute_instance" "us-west1-a-1" {
   name         = "foundations-us-west1-a-1"
   machine_type = "e2-micro"
+  zone         = "us-west1-a"
 
   boot_disk {
     initialize_params {
       image = "ubuntu-os-cloud/ubuntu-minimal-2204-lts"
     }
+    disk_encryption_key_raw = google_kms_crypto_key.foundations-1-1
   }
 
   network_interface {
     network = "default"
-    access_config {
-    }
+  }
+
+  metadata = {
+    block-project-ssh-keys = true
+  }
+
+  shielded_instance_config {
+    enable_vtpm                 = true
+    enable_integrity_monitoring = true
   }
 }

--- a/vms.tf
+++ b/vms.tf
@@ -39,7 +39,7 @@ resource "google_compute_instance" "us-west1-a-1" {
     initialize_params {
       image = "ubuntu-os-cloud/ubuntu-minimal-2204-lts"
     }
-    disk_encryption_key_raw = google_kms_crypto_key.disk-1-1.id
+    kms_key_self_link = google_kms_crypto_key.disk-1-1.id
   }
 
   network_interface {


### PR DESCRIPTION
This PR tries to provision a new free-tier VM on Google Compute Engine under the sargassum-world project. It's intended to host a single non-HA deployment of Nomad, Vault, Consul, etc.