### PR TITLE
Try to fix issue with incorrect key permissions for tf service account

### DIFF
--- a/vars.tf
+++ b/vars.tf
@@ -1,0 +1,3 @@
+variable "gcp_service_account" {
+  type = string
+}

--- a/vms.tf
+++ b/vms.tf
@@ -16,13 +16,20 @@ provider "google" {
 }*/
 
 resource "google_kms_key_ring" "disks-1" {
-  name     = "foundations-1"
+  name     = "foundations-disks-1"
   location = "global"
 }
 
+resource "google_kms_key_ring_iam_member" "disks-1-service-tf" {
+  key_ring_id = google_kms_key_ring.disks-1.id
+  role        = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member      = var.gcp_service_account
+}
+
 resource "google_kms_crypto_key" "disk-1-1" {
-  name            = "foundations-1"
+  name            = "foundations-disk-1-1"
   key_ring        = google_kms_key_ring.disks-1.id
+  purpose         = "ENCRYPT_DECRYPT"
   rotation_period = "7770000s"
 
   lifecycle {

--- a/vms.tf
+++ b/vms.tf
@@ -32,9 +32,10 @@ resource "google_kms_crypto_key" "disk-1-1" {
   purpose         = "ENCRYPT_DECRYPT"
   rotation_period = "7770000s"
 
-  lifecycle {
+  // TODO: restore this lifecycle hook!
+  /*lifecycle {
     prevent_destroy = true
-  }
+  }*/
 }
 
 resource "google_compute_instance" "us-west1-a-1" {


### PR DESCRIPTION
The GCP VM couldn't be provisioned because Terraform encountered the following error:

> Error: Error creating instance: googleapi: Error 400: Cloud KMS error when using key projects/sargassum-world/locations/global/keyRings/foundations-1/cryptoKeys/foundations-1: Permission 'cloudkms.cryptoKeyVersions.useToEncrypt' denied on resource 'projects/sargassum-world/locations/global/keyRings/foundations-1/cryptoKeys/foundations-1' (or it may not exist)., kmsPermissionDenied
with google_compute_instance.us-west1-a-1
on vms.tf line 33, in resource "google_compute_instance" "us-west1-a-1":

As described in [this StackOverflow thread](https://stackoverflow.com/questions/53150044/getting-error-while-generating-crypto-keys-using-gcloud-kms-to-access-private-re), this error is probably because the GCP service account for Terraform does not have the proper permissions to use the encryption key.