### PR TITLE
Try to make a VPC and NAT for internet access

### DIFF
--- a/vms-gcp.tf
+++ b/vms-gcp.tf
@@ -13,6 +13,12 @@ resource "google_compute_subnetwork" "foundations-us-west1" {
   network       = google_compute_network.foundations.id
   region        = "us-west1"
   ip_cidr_range = "10.128.0.0/24"
+  
+  log_config {
+    aggregation_interval = "INTERVAL_10_MIN"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
 }
 
 resource "google_kms_key_ring" "disks-1" {

--- a/vms-gcp.tf
+++ b/vms-gcp.tf
@@ -21,6 +21,29 @@ resource "google_compute_subnetwork" "foundations-us-west1" {
   }
 }
 
+resource "google_compute_router" "us-west1" {
+  name    = "foundations-us-west1"
+  region  = "us-west1"
+  network = google_compute_network.foundations.id
+  
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_nat" "us-west1" {
+  name                               = "foundations-us-west1"
+  router                             = google_compute_router.us-west1.name
+  region                             = "us-west1"
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+
 resource "google_kms_key_ring" "disks-1" {
   name     = "foundations-disks-1"
   location = "global"
@@ -55,7 +78,6 @@ resource "google_kms_crypto_key" "disk-1-1" {
 
 resource "google_compute_instance" "us-west1-a-1" {
   name         = "foundations-us-west1-a-1"
-  region       = "us-west1"
   zone         = "us-west1-a"
   machine_type = "e2-micro"
 
@@ -77,28 +99,5 @@ resource "google_compute_instance" "us-west1-a-1" {
   shielded_instance_config {
     enable_vtpm                 = true
     enable_integrity_monitoring = true
-  }
-}
-
-resource "google_compute_router" "us-west1" {
-  name    = "foundations-us-west1"
-  region  = "us-west1"
-  network = google_compute_network.foundations.id
-  
-  bgp {
-    asn = 64514
-  }
-}
-
-resource "google_compute_router_nat" "us-west1" {
-  name                               = "foundations-us-west1"
-  router                             = google_compute_router.us-west1.name
-  region                             = "us-west1"
-  nat_ip_allocate_option             = "AUTO_ONLY"
-  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-  
-  log_config {
-    enable = true
-    filter = "ERRORS_ONLY"
   }
 }


### PR DESCRIPTION
This PR adds configuration for a VPC (with custom subnets) and a Cloud NAT so that Google Compute Engine VMs (which we are configuring without public IP addresses, for security reasons) can still access the internet.