### PR TITLE
Change IP CIDR range for subnet

### DIFF
--- a/vms-gcp.tf
+++ b/vms-gcp.tf
@@ -12,7 +12,7 @@ resource "google_compute_subnetwork" "foundations-us-west1" {
   name          = "foundations-us-west1"
   network       = google_compute_network.foundations.id
   region        = "us-west1"
-  ip_cidr_range = "10.128.0.0/24"
+  ip_cidr_range = "10.64.0.0/24"
   
   log_config {
     aggregation_interval = "INTERVAL_10_MIN"


### PR DESCRIPTION
The last run gave the following error:
> googleapi: Error 400: Invalid value for field 'resource.ipCidrRange': '10.128.0.0/24'. Extended subnetworks in auto subnet mode networks cannot overlap with 10.128.0.0/9., invalid
with google_compute_subnetwork.foundations-us-west1

Hopefully this PR fixes the problem by using range 10.64.0.0/24 instead of 10.128.0.0/24, as 10.128.0.0/9 is reserved for GCP's auto mode VPC networks.