### PR TITLE
Assign external IP to orchestrator VM

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -40,6 +40,26 @@ provider "registry.terraform.io/hashicorp/nomad" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/tfe" {
+  version     = "0.37.0"
+  constraints = "~> 0.37.0"
+  hashes = [
+    "h1:VeCmmlmx9MFiEOzZn40IiqYcg5qjT5HN4txbPC5z2Hk=",
+    "zh:04ac7d56a2222874f43411dff2ae3daa78a37353313dbd7b4d1f6f896596761c",
+    "zh:0c7468ab225c6a3d3660bc3daf6f5b1a1cbb586a86af32ec2bc7c2af489f6e49",
+    "zh:3245b66e7f11daed90fa2209ab3414cf5494a6216b408e9ee2458783679bb4b9",
+    "zh:4768b1f28c876ec86d399945402cbdb955aae1c018987e8419490a01c5b5f810",
+    "zh:4a9359fa084697fe38c89fbc8a0059238f71d8613493fc14dba5a3f59fafbe37",
+    "zh:4b4bb9dd18904c9a7155bb5ce4001975b64e728ff46e09084ef42b8ffb83fff4",
+    "zh:5a05d499ffec4cd6c3c9f8fc5f93cf9f05fb955ed06a6d701ba63e43d4da1d36",
+    "zh:8683cc99fef9694e727dc5ba995425c6392844bdd2dc489284265399382360d8",
+    "zh:9a1b197a6a0a46f72fab69dd4ce4cba358debf808f95d9601c41e08161a105bc",
+    "zh:d95ec293fa70e946b6cd657912b33155f8be3413e6128ed2bfa5a493f788e439",
+    "zh:dc27f5753b5567a0a2b708b44e7ed68754fa3e88eb8ad4bbacd1d1b809c62484",
+    "zh:eb57cba527d63888e6894dd2d80674d7b988534126963c0520b1def6cb3a2d5e",
+  ]
+}
+
 provider "registry.terraform.io/zerotier/zerotier" {
   version     = "1.2.0"
   constraints = "~> 1.2.0"

--- a/gcp-compute.tf
+++ b/gcp-compute.tf
@@ -52,6 +52,11 @@ resource "google_compute_instance" "us_west1_a_1" {
 
   network_interface {
     subnetwork = google_compute_subnetwork.foundations_us_west1.id
+
+    access_config {
+      nat_ip       = google_compute_address.us_west1_a_1.address
+      network_tier = "PREMIUM"
+    }
   }
 
   metadata = {

--- a/gcp-compute.tf
+++ b/gcp-compute.tf
@@ -63,7 +63,7 @@ resource "google_compute_instance" "us_west1_a_1" {
     block-project-ssh-keys = true
   }
 
-  tags = ["iap-ssh", "zerotier"]
+  tags = ["iap-ssh", "zerotier-agent", "nomad-api", "nomad-server", "nomad-client"]
 
   shielded_instance_config {
     enable_vtpm                 = true

--- a/gcp-networking.tf
+++ b/gcp-networking.tf
@@ -16,6 +16,8 @@ resource "google_compute_firewall" "allow_iap_forwarded_ssh" {
   target_tags   = ["iap-ssh"]
 }
 
+# TODO: is this needed? defsec warns against allowing ingress traffic from /0 on the public internet
+/*
 resource "google_compute_firewall" "allow_zerotier_udp" {
   name    = "allow-zerotier"
   network = google_compute_network.foundations.name
@@ -28,6 +30,7 @@ resource "google_compute_firewall" "allow_zerotier_udp" {
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["zerotier-agent"]
 }
+*/
 
 resource "google_compute_firewall" "allow_zerotier_tcp" {
   name    = "allow-zerotier"

--- a/gcp-networking.tf
+++ b/gcp-networking.tf
@@ -90,3 +90,12 @@ resource "google_compute_router_nat" "us_west1" {
     filter = "ERRORS_ONLY"
   }
 }
+
+# External IP Addresses
+
+resource "google_compute_address" "us_west1_a_1" {
+  name         = "foundations-us-west1-a-1"
+  address_type = "EXTERNAL"
+  purpose      = "GCE_ENDPOINT"
+  network_tier = "PREMIUM"
+}

--- a/gcp-networking.tf
+++ b/gcp-networking.tf
@@ -16,8 +16,8 @@ resource "google_compute_firewall" "allow_iap_forwarded_ssh" {
   target_tags   = ["iap-ssh"]
 }
 
-resource "google_compute_firewall" "allow_zerotier_ingress" {
-  name    = "allow-zerotier-ingress"
+resource "google_compute_firewall" "allow_zerotier_udp" {
+  name    = "allow-zerotier"
   network = google_compute_network.foundations.name
 
   allow {
@@ -26,19 +26,72 @@ resource "google_compute_firewall" "allow_zerotier_ingress" {
   }
 
   source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["zerotier"]
+  target_tags   = ["zerotier-agent"]
 }
 
-resource "google_compute_firewall" "allow_zerotier_egress" {
-  name      = "allow-zerotier-egress"
-  network   = google_compute_network.foundations.name
-  direction = "EGRESS"
+resource "google_compute_firewall" "allow_zerotier_tcp" {
+  name    = "allow-zerotier"
+  network = google_compute_network.foundations.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9993"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["zerotier-api"]
+}
+
+resource "google_compute_firewall" "allow_nomad_http" {
+  name    = "allow-nomad-http"
+  network = google_compute_network.foundations.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["4646"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["nomad-api"]
+}
+
+resource "google_compute_firewall" "allow_nomad_rpc" {
+  name    = "allow-nomad-rpc"
+  network = google_compute_network.foundations.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["4647"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["nomad-server", "nomad-client"]
+}
+
+resource "google_compute_firewall" "allow_nomad_serf_tcp" {
+  name    = "allow-nomad-serf-tcp"
+  network = google_compute_network.foundations.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["4648"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["nomad-server"]
+}
+
+resource "google_compute_firewall" "allow_nomad_serf_udp" {
+  name    = "allow-nomad-serf-udp"
+  network = google_compute_network.foundations.name
 
   allow {
     protocol = "udp"
+    ports    = ["4648"]
   }
 
-  target_tags = ["zerotier"]
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["nomad-server"]
 }
 
 # Note: the service account can't just give itself whatever permissions it wants, so this step

--- a/gcp-networking.tf
+++ b/gcp-networking.tf
@@ -32,6 +32,8 @@ resource "google_compute_firewall" "allow_zerotier_udp" {
 }
 */
 
+# TODO: do we need to allow public access to ZeroTier APIs?
+/*
 resource "google_compute_firewall" "allow_zerotier_tcp" {
   name    = "allow-zerotier"
   network = google_compute_network.foundations.name
@@ -44,9 +46,10 @@ resource "google_compute_firewall" "allow_zerotier_tcp" {
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["zerotier-api"]
 }
+*/
 
-resource "google_compute_firewall" "allow_nomad_http" {
-  name    = "allow-nomad-http"
+resource "google_compute_firewall" "allow_nomad_http_terraform" {
+  name    = "allow-nomad-http-terraform"
   network = google_compute_network.foundations.name
 
   allow {
@@ -54,10 +57,12 @@ resource "google_compute_firewall" "allow_nomad_http" {
     ports    = ["4646"]
   }
 
-  source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["nomad-api"]
+  source_ranges = data.tfe_ip_ranges.addresses.vcs
+  target_tags   = ["nomad-api-terraform"]
 }
 
+# We don't need to connect to clients over the public internet yet
+/*
 resource "google_compute_firewall" "allow_nomad_rpc" {
   name    = "allow-nomad-rpc"
   network = google_compute_network.foundations.name
@@ -70,7 +75,10 @@ resource "google_compute_firewall" "allow_nomad_rpc" {
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["nomad-server", "nomad-client"]
 }
+*/
 
+# We don't need Nomad server clustering yet
+/*
 resource "google_compute_firewall" "allow_nomad_serf_tcp" {
   name    = "allow-nomad-serf-tcp"
   network = google_compute_network.foundations.name
@@ -96,6 +104,7 @@ resource "google_compute_firewall" "allow_nomad_serf_udp" {
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["nomad-server"]
 }
+*/
 
 # Note: the service account can't just give itself whatever permissions it wants, so this step
 # actually has to be performed manually in the Google Cloud console. Just go to the Identity-Aware

--- a/nomad-jobs.tf
+++ b/nomad-jobs.tf
@@ -1,6 +1,6 @@
 resource "nomad_job" "zerotier_agent" {
   jobspec = templatefile("${path.module}/nomad-job-zerotier-agent.hcl.tftpl", {
-    group       = "gcp_us_west1_a_1"
+    group       = "zerotier_agent_gcp_us_west1_a_1"
     private_key = zerotier_identity.gcp_us_west1_a_1.private_key
     public_key  = zerotier_identity.gcp_us_west1_a_1.public_key
   })

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,5 @@
+provider "tfe" {}
+
 provider "zerotier" {}
 
 provider "google" {

--- a/terraform-cloud.tf
+++ b/terraform-cloud.tf
@@ -1,0 +1,2 @@
+data "tfe_ip_ranges" "addresses" {}
+

--- a/versions.tf
+++ b/versions.tf
@@ -8,6 +8,10 @@ terraform {
   }
 
   required_providers {
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = "~>0.37.0"
+    }
     zerotier = {
       source  = "zerotier/zerotier"
       version = "~> 1.2.0"


### PR DESCRIPTION
This PR assigns a static public IP address to the GCP VM for the orchestrator. This is needed because:

- In order to use Terraform to manage Nomad jobs for foundational infrastructure, it needs to access the Nomad server on an IP address.
- Terraform Cloud on the free plan can only access things with public IP addresses. Terraform Cloud Agents would solve this problem but are only available on the Business plan.
- Without an external IP address, we'd have to use GCP's Cloud Load Balancer, which is unaffordable (no free tier, and a single forwarding rule is $18/month).

In the future, we can just use this VM as a bastion or jump host for Terraform (e.g. with [this module](https://github.com/flaupretre/terraform-ssh-tunnel)) and keep other foundational infrastructure VMs only on private IP addresses.