### PR TITLE
Expose the Nomad HTTP API directly

### DIFF
--- a/gcp-networking.tf
+++ b/gcp-networking.tf
@@ -32,24 +32,8 @@ resource "google_compute_firewall" "allow_zerotier_udp" {
 }
 */
 
-# TODO: do we need to allow public access to ZeroTier APIs?
-/*
-resource "google_compute_firewall" "allow_zerotier_tcp" {
-  name    = "allow-zerotier"
-  network = google_compute_network.foundations.name
-
-  allow {
-    protocol = "tcp"
-    ports    = ["9993"]
-  }
-
-  source_ranges = ["0.0.0.0/0"]
-  target_tags   = ["zerotier-api"]
-}
-*/
-
-resource "google_compute_firewall" "allow_nomad_http_terraform" {
-  name    = "allow-nomad-http-terraform"
+resource "google_compute_firewall" "allow_nomad_http" {
+  name    = "allow-nomad-http"
   network = google_compute_network.foundations.name
 
   allow {
@@ -57,8 +41,8 @@ resource "google_compute_firewall" "allow_nomad_http_terraform" {
     ports    = ["4646"]
   }
 
-  source_ranges = data.tfe_ip_ranges.addresses.vcs
-  target_tags   = ["nomad-api-terraform"]
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["nomad-api"]
 }
 
 # We don't need to connect to clients over the public internet yet

--- a/providers.tf
+++ b/providers.tf
@@ -10,4 +10,6 @@ provider "google" {
 
 provider "nomad" {
   address = "https://${google_compute_address.us_west1_a_1.address}:4646"
+  # Note: the Nomad server should be locked down with the ACL system, e.g. with the NOMAD_TOKEN
+  # environment variable
 }

--- a/zerotier-networking.tf
+++ b/zerotier-networking.tf
@@ -25,6 +25,7 @@ resource "zerotier_member" "gcp_us_west1_a_1" {
   network_id = zerotier_network.foundations.id
 }
 
+# TODO: specify administrative members through a Terraform variable
 resource "zerotier_member" "ethan_vulcan" {
   name       = "ethan-vulcan"
   member_id  = "cb1b5001de"


### PR DESCRIPTION
This PR adds an inbound firewall rule to expose the Nomad HTTP API directly to the world by allowing inbound traffic from 0/, despite a defsec error. This is needed for the reasons discussed in #9, and furthermore because:

- Terraform Cloud [does not expose](https://www.terraform.io/cloud-docs/architectural-details/ip-ranges) the IP address ranges it uses for accessing local resources such as a Nomad server.
- Terraform does not seem to provide a built-in way to access a resource through an SSH tunnel, in which case we could access the Nomad HTTP API through a bastion/jump host or by setting up an SSH tunnel from the orchestrator VM to Terraform Cloud.
- The [flaupretre/tunnel/ssh](https://registry.terraform.io/modules/flaupretre/tunnel/ssh/latest) Terraform module enables setting up an SSH tunnel to configure resources behind a bastion host, but it requires either passing the path to an SSH private key file or having the SSH private key in the environment (e.g. with an SSH agent), and I don't think there's a way to make a file, run an SSH agent, etc, in Terraform Cloud (Terraform Cloud says that SSH keys are only supported for downloading Terraform modules from Git-based module sources, so it doesn't provide a built-in way to set SSH keys for running modules).

For security, the orchestrator VM image should configure Nomad with a bootstrap ACL token (see https://github.com/sargassum-world/vm-orchestrator/commit/6d5465e2dd2a75ef82e6e698f64b79dae38ffd42 and https://github.com/sargassum-world/vm-orchestrator/commit/71c45daeb9494ee5f3a6b66c2e9397043e5b6f98), which is set as the NOMAD_TOKEN environment variable secret in Terraform Cloud.