### PR TITLE
Change GCP firewall to expose ZeroTier port to the public internet

### DIFF
--- a/gcp-networking.tf
+++ b/gcp-networking.tf
@@ -16,8 +16,6 @@ resource "google_compute_firewall" "allow_iap_forwarded_ssh" {
   target_tags   = ["iap-ssh"]
 }
 
-# TODO: is this needed? defsec warns against allowing ingress traffic from /0 on the public internet
-/*
 resource "google_compute_firewall" "allow_zerotier_udp" {
   name    = "allow-zerotier"
   network = google_compute_network.foundations.name
@@ -30,7 +28,6 @@ resource "google_compute_firewall" "allow_zerotier_udp" {
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["zerotier-agent"]
 }
-*/
 
 resource "google_compute_firewall" "allow_nomad_http" {
   name    = "allow-nomad-http"

--- a/nomad-jobs/zerotier-agent.hcl.tftpl
+++ b/nomad-jobs/zerotier-agent.hcl.tftpl
@@ -42,8 +42,8 @@ job "zerotier_agent" {
       }
 
       resources {
-        cpu    = 100
-        memory = 64
+        cpu    = 128
+        memory = 32
       }
     }
   }


### PR DESCRIPTION
This PR exposes the orchestrator VM's UDP port 9993 to the public internet, in an attempt to make the ZeroTier agent running on the orchestrator VM able to establish connections with peers.