### PR TITLE
Try running a Caddy hello world test server

### DIFF
--- a/gcp-compute-orchestrators.tf
+++ b/gcp-compute-orchestrators.tf
@@ -19,6 +19,9 @@ resource "google_compute_disk" "us_west1_a_1_data" {
   lifecycle {
     prevent_destroy = true
   }
+
+  # After creation, this disk needs to be manually formatted following the instructions at
+  # https://cloud.google.com/compute/docs/disks/add-persistent-disk#formatting
 }
 
 # Note: depends on google_project_service.compute

--- a/gcp-networking.tf
+++ b/gcp-networking.tf
@@ -88,17 +88,18 @@ resource "google_compute_firewall" "allow_nomad_serf_udp" {
 }
 */
 
-# Note: the service account can't just give itself whatever permissions it wants, so this step
-# actually has to be performed manually in the Google Cloud console. Just go to the Identity-Aware
-# Proxy panel, enable the Identity-Aware Proxy API (if needed), select the SSH and TCP Resources
-# tab, check the checkbox for "All Tunnel Resources", click "Add Principal" in the right pane, and
-# add the GCP service account for Terraform to the "New principals" field and the IAP-secured Tunnel
-# User role to the Roles dropdown.
-/*resource "google_project_iam_member" "iap_terraform" {
-  project = var.gcp_project_id
-  role    = "roles/iap.tunnelResourceAccessor"
-  member  = var.gcp_terraform_service_account
-}*/
+resource "google_compute_firewall" "allow_http" {
+  name    = "allow-http"
+  network = google_compute_network.foundations.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["http_server"]
+}
 
 # us-west1 Region
 

--- a/nomad-jobs.tf
+++ b/nomad-jobs.tf
@@ -1,3 +1,4 @@
+# TODO: move these jobs into the gcp-compute-orchestrators.tf file
 resource "nomad_job" "zerotier_agent" {
   jobspec = templatefile("${path.module}/nomad-jobs/zerotier-agent.hcl.tftpl", {
     group       = "gcp_us_west1_a_1"
@@ -5,6 +6,17 @@ resource "nomad_job" "zerotier_agent" {
     private_key = zerotier_identity.gcp_us_west1_a_1.private_key
     public_key  = zerotier_identity.gcp_us_west1_a_1.public_key
     network     = zerotier_network.foundations.id
+  })
+
+  hcl2 {
+    enabled = true
+  }
+}
+
+resource "nomad_job" "caddy" {
+  jobspec = templatefile("${path.module}/nomad-jobs/caddy.hcl.tftpl", {
+    group    = "gcp_us_west1_a_1"
+    affinity = google_compute_instance.us_west1_a_1.name
   })
 
   hcl2 {

--- a/nomad-jobs/caddy.hcl.tftpl
+++ b/nomad-jobs/caddy.hcl.tftpl
@@ -1,0 +1,69 @@
+job "caddy" {
+  type = "service"
+  datacenters = ["sargassum-foundations"]
+
+  update {
+    max_parallel = 1
+  }
+
+  group "${group}" {
+    count = 1
+
+    affinity {
+      attribute = "$${attr.unique.hostname}" # Nomad variable, not Terraform template variable
+      value     = "${affinity}"
+    }
+
+    network {
+      mode = "host"
+
+      port "http" {
+        static = 80
+      }
+
+      port "https" {
+        static = 443
+      }
+    }
+
+    task "public" {
+      driver = "docker"
+
+      config {
+        image        = "caddy:2.6.1"
+        ports        = ["http", "https"]
+        network_mode = "host"
+
+        mount {
+          type     = "volume"
+          target   = "/data"
+          source   = "caddy_public-data"
+          readonly = false
+        }
+
+        mount {
+          type     = "bind"
+          target   = "/etc/caddy/Caddyfile"
+          source   = "local/Caddyfile"
+          readonly = true
+        }
+      }
+
+      template {
+        source        = "./caddy_public_Caddyfile.tpl"
+        destination   = "local/Caddyfile"
+        change_mode   = "script"
+        change_script {
+          command = "caddy"
+          args    = ["reload"]
+        }
+      }
+
+      resources {
+        cpu        = 200
+        memory     = 128
+        memory_max = 256
+      }
+    }
+  }
+}

--- a/nomad-jobs/caddy_public_Caddyfile.tpl
+++ b/nomad-jobs/caddy_public_Caddyfile.tpl
@@ -1,0 +1,3 @@
+:80
+
+respond "hello, world!"

--- a/nomad-jobs/zerotier-agent.hcl.tftpl
+++ b/nomad-jobs/zerotier-agent.hcl.tftpl
@@ -10,7 +10,7 @@ job "zerotier_agent" {
     count = 1
 
     affinity {
-      attribute = "$${attr.unique.hostname}"
+      attribute = "$${attr.unique.hostname}" # Nomad variable, not Terraform template variable
       value     = "${affinity}"
     }
 
@@ -45,8 +45,9 @@ job "zerotier_agent" {
       }
 
       resources {
-        cpu    = 150
-        memory = 32
+        cpu        = 200
+        memory     = 32
+        memory_max = 128
       }
     }
   }


### PR DESCRIPTION
This PR attempts to use Nomad to set up a Caddy server, currently running a hello-world test. This will later serve as a reverse proxy on the public internet, so it needs to be  exposed to 0.0.0.0/0.

The Caddy configuration is set from a Nomad-templated file, though the template source path may not work correctly since the Nomad job is first being submitted by Terraform - in which case this PR will fail to complete deployment and we will need to figure out a different way to provide the Caddyfile template.