### PR TITLE
Add a GCP firewall rule to serve HTTP/3 to the public internet

### DIFF
--- a/modules/gcp-vpc-network/gcp.tf
+++ b/modules/gcp-vpc-network/gcp.tf
@@ -99,3 +99,16 @@ resource "google_compute_firewall" "allow_http" {
   source_ranges = ["0.0.0.0/0"]
   target_tags   = ["http-server"]
 }
+
+resource "google_compute_firewall" "allow_http3" {
+  name    = "allow-http"
+  network = google_compute_network.network.name
+
+  allow {
+    protocol = "udp"
+    ports    = ["80", "443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["http3-server"]
+}

--- a/orchestrators.tf
+++ b/orchestrators.tf
@@ -27,6 +27,7 @@ module "orchestrator_gcp_us_west1_a_1" {
   gcp_machine_type = "e2-micro"
   gcp_tags = [
     "iap-ssh", "zerotier-agent", "nomad-api", "nomad-server", "nomad-client", "http-server",
+    "http3-server",
   ]
   gcp_boot_disk_image      = var.gcp_vm_orchestrator_image
   gcp_boot_disk_kms_key_id = google_kms_crypto_key.disk_global_1_1.id


### PR DESCRIPTION
This PR adds a GCP firewall rule to allow inbound UDP traffic on ports 80 and 443 from the public internet, for HTTP/3.